### PR TITLE
`FLOAT` type support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-model-settings` will be documented in this file
 
+## 1.8.0 - 2024-11-28
+
+- `FLOAT` type support
+
 ## 1.7.0 - 2024-03-04
 
 - Laravel 11 support

--- a/src/Enums/Type.php
+++ b/src/Enums/Type.php
@@ -8,6 +8,7 @@ enum Type: string
 {
     case STRING = 'string';
     case INT = 'int';
+    case FLOAT = 'float';
     case JSON = 'json';
     case ARRAY = 'array';
     case BOOLEAN = 'bool';

--- a/tests/Models/SettingModelTest.php
+++ b/tests/Models/SettingModelTest.php
@@ -29,6 +29,20 @@ class SettingModelTest extends TestCase
         $this->assertSame('1', $setting->getRawOriginal('value'));
     }
 
+    public function testFloatCast(): void
+    {
+        $setting = new $this->settingModel();
+        $setting->model_type = 'whatever';
+        $setting->model_id = 1;
+        $setting->key = 'whatever';
+        $setting->type = Type::FLOAT;
+        $setting->value = '1.23';
+        $setting->save();
+
+        $this->assertSame(1.23, $setting->value);
+        $this->assertSame('1.23', $setting->getRawOriginal('value'));
+    }
+
     public function testStringCast(): void
     {
         $setting = new $this->settingModel();


### PR DESCRIPTION
This PR adds a `FLOAT` type support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for the `FLOAT` data type in the `laravel-model-settings` package.
	- Updated changelog to reflect the new version 1.8.0 and its features.

- **Tests**
	- Added a new test for verifying the functionality of casting a setting value to a float type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->